### PR TITLE
Override where so that we can provide no arguments

### DIFF
--- a/star_alchemy/_star_alchemy.py
+++ b/star_alchemy/_star_alchemy.py
@@ -49,6 +49,14 @@ class StarSchemaSelect(sa.sql.expression.Select):
         super().__init__(*args, **kwargs)
         self.star_schema = star_schema
 
+    def where(self, *args):
+        """
+        Override `where` to support `where()` i.e. empty list, this is useful
+        for dynamically generated where clauses
+        TODO: Maybe see if we can build this upstream into sqlalchemy
+        """
+        return super().where(*args) if args else self
+
 
 @attr.s(auto_attribs=True, hash=False, order=False)
 class StarSchema:

--- a/tests/test_star_schema.py
+++ b/tests/test_star_schema.py
@@ -199,6 +199,13 @@ class StarSchemaQueryTestCase(TestCase, AssertQueryEqualMixin):
         product = self.sales.detach('product')
         return product.select([product.tables['category'].c.id])
 
+    @query_test(expected="""
+        SELECT sale.id
+        FROM sale
+    """)
+    def test_where_should_accept_no_arguments(self):
+        return self.sales.select([self.sales.tables['sale'].c.id]).where()
+
 
 class DocStringTestCase(TestCase, DocTestMixin(_star_alchemy)):
     """


### PR DESCRIPTION
This is useful when dynamically generating a where clauses when there may or may not be expressions generated, for example, imagine we have a web api that gives a json blob like this for some filters that should be applied...

```
topology = StarSchema.from_dicts({...})  # ommitted for brevity

filters = {
    'price': [0, 32],
    'categories': ['shoes', 't-shirts', 'socks']
}

query = (
    topology
    .select([product.c.id])
    .where(*filters_to_expressions(topology, filters))
)
```

Here `filters_to_expression` is a function which converts this json blob to a list of expressions (omitted for brevity, but you can probably imagine how it looks). It could be that the API doesn't give a filter, or that `filters_to_expression` decides that certain filters don't need applying (for example if they wouldn't actually filter anything out). The sqlalchemy version of `where` does not support giving no arguments, there are a couple of workarounds, e.g.

```
# makes your python code nastier than needed
query =  topology.select([product.c.id])
if (expressions := filters_to_expressions(topology, filters)):
    query = query.where(expressions)
```

Or

```
# makes your sql code nastier than needed
query = (
    topology
    .select([product.c.id])
    .where(sa.literal(True), *filters_to_expressions(topology, filters))
)
```

But supporting an empty args in where means we don't need this ugly workarounds

NOTE: It is probably nicer to see if we can get this supported in sqlalchey itself to keep the differences minimal