### PR TITLE
Make custom joins more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ galaxy schemas.
 ... )
 ```
 
+- Customise the joins if necessary:
+
+```python
+>>> from star_alchemy import Schema, Join
+>>> from tests import tables
+>>> definition = {
+...     tables.sale: {
+...         tables.product: {},
+...     },
+... }
+>>> joins = {
+...     (tables.sale, tables.product): Join(isouter=False)
+... }
+>>> schema = Schema(definition, joins)
+```
+
 - Detach to create smaller sub schemas..
 
 (TODO)

--- a/star_alchemy/__init__.py
+++ b/star_alchemy/__init__.py
@@ -1,3 +1,3 @@
-from star_alchemy._star_schema import Schema
+from star_alchemy._star_schema import Join, Schema
 
-__all__ = ["Schema"]
+__all__ = ["Schema", "Join"]

--- a/star_alchemy/_star_schema.py
+++ b/star_alchemy/_star_schema.py
@@ -15,7 +15,7 @@ OnClause = typing.Callable[[Selectable, Selectable], ClauseElement]
 @dataclasses.dataclass
 class Join:
     on_clause_func: OnClause | None = None
-    isouter: bool = False
+    isouter: bool = True
     full: bool = False
 
     def __post_init__(self):

--- a/tools/fix
+++ b/tools/fix
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# std
+from subprocess import call
+from shlex import split
+
+_ = lambda x: call(split(x))
+header = lambda x: print('\n' + f' {x} '.center(70, '='), end='\n\n')
+
+header('fix lint')
+_('isort star_alchemy tests')
+_('black star_alchemy tests')

--- a/tools/qa
+++ b/tools/qa
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
-
-# run quality assurance checks
-
+# std
+import sys
+from pprint import pprint
 from subprocess import call
 from shlex import split
+# 3rd party
+from toolz import valfilter, identity
 
-_ = lambda x: call(split(x))
+# run all quality assurance checks, report errors
+
+results = []
+
+_ = lambda x: results.append((x, call(split(x))))
 header = lambda x: print('\n' + f' {x} '.center(70, '='), end='\n\n')
 
 header('lint')
@@ -18,3 +24,7 @@ _('mypy star_alchemy')
 header('unit tests')
 _('python -m unittest discover tests')
 
+if (failed := valfilter(identity, dict(results))):
+    print('\nFAILED COMMANDS:\n')
+    pprint(failed)
+    sys.exit(1)


### PR DESCRIPTION
At the moment when we generate joins we hardcode `isouter=True`. However we need to be able to specify `inner` and `full outer join`. 

It is currently possible to customize the  `on_clauses` of a schema. In this PR I have extended this concept so that one can now fully customize the `joins` of a schema (only where necessary). This is a dictionary mapping (left, right) tables (the tables which should be joied) to either a function which just defines the on clause (assumes `left outer join`) or an instance of the `Join` dataclass where one can fully control the `on_clause`, `isouter` and `full` parameters of the join. The following defaults are used...

* `on_clause` : Automatically derive the on clause from foreign keys (use `Schema._default_on_clause`)
* `isouter`: `True` - default to outer join
* `full`: `False` - default to left outer join