### PR TITLE
Allow dynamically generated tables (using sa.text)

### DIFF
--- a/star_alchemy/_star_schema.py
+++ b/star_alchemy/_star_schema.py
@@ -1,11 +1,10 @@
 import dataclasses
 import typing
 from functools import cached_property, partial
-from typing import TypedDict
 
-from sqlalchemy import Column
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql import ClauseElement, FromClause, Select, Selectable, visitors
+from sqlalchemy.sql.elements import ColumnClause
 from toolz import first, sliding_window, unique
 
 LeftRight = tuple[Selectable, Selectable]
@@ -192,7 +191,9 @@ def _compile_schema_select(select: Schema._Select, compiler, **kw):
         return compiled
 
     # get the columns (and thus the tables) from the sub-expressions involved in this query
-    tables = {x.table for x in visitors.iterate(select, {}) if isinstance(x, Column)}
+    tables = {
+        x.table for x in visitors.iterate(select, {}) if isinstance(x, ColumnClause)
+    }
 
     # TODO: Perhaps only join to lowest common root rather than root? For example
     #  if there are no expressions coming directly from job, do we always need to

--- a/tests/tables.py
+++ b/tests/tables.py
@@ -9,6 +9,7 @@ sale = sa.Table(
     sa.Column("product_id", sa.Integer, sa.ForeignKey("product.id")),
     sa.Column("employee_id", sa.Integer, sa.ForeignKey("employee.id")),
     sa.Column("customer_id", sa.Integer, sa.ForeignKey("customer.id")),
+    sa.Column("dynamic_id", sa.Integer),
     sa.Column("total", sa.Integer),
     sa.Column("quantity", sa.Integer),
     sa.Column("discount", sa.Integer),


### PR DESCRIPTION
This change allows generating queries for dynamic tables, for example `sa.text('select 1 as id').columns(id=sa.INT).cte('dynamic')`